### PR TITLE
use reserved lambda session token

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -8,6 +8,7 @@ const {
     AWS_PROFILE,
     AWS_ACCESS_KEY_ID,
     AWS_SECRET_ACCESS_KEY,
+    AWS_SESSION_TOKEN,
 
     AWS_DYNAMO_ENDPOINT,
 } = process.env;
@@ -20,6 +21,7 @@ module.exports = {
     AWS_PROFILE,
     AWS_ACCESS_KEY_ID,
     AWS_SECRET_ACCESS_KEY,
+    AWS_SESSION_TOKEN,
 
     AWS_DYNAMO_ENDPOINT,
 };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://www.krashidbuilt.com"
   },
   "copyright": "© KrashidBuilt 2021",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "main": "index.js",
   "license": "MIT",
   "scripts": {

--- a/src/Dynamo.js
+++ b/src/Dynamo.js
@@ -2,7 +2,7 @@ const isEqual = require('lodash.isequal');
 const { DynamoDB, DynamoDBClient, CreateTableCommand, ListTablesCommand, DescribeTableCommand, DeleteTableCommand, UpdateTimeToLiveCommand, waitForTableExists, waitForTableNotExists } = require('@aws-sdk/client-dynamodb');
 const { marshall, unmarshall } = require('@aws-sdk/util-dynamodb');
 
-const { AWS_DEFAULT_REGION, AWS_DYNAMO_ENDPOINT, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY } = require('../constants');
+const { AWS_DEFAULT_REGION, AWS_DYNAMO_ENDPOINT, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN } = require('../constants');
 
 const Logger = require('@KrashidBuilt/common/utils/logger');
 const logger = new Logger(__filename);
@@ -11,11 +11,12 @@ const config = {
     region: AWS_DEFAULT_REGION,
 };
 
-if (AWS_ACCESS_KEY_ID && AWS_SECRET_ACCESS_KEY) {
+if (AWS_ACCESS_KEY_ID && AWS_SECRET_ACCESS_KEY && AWS_SESSION_TOKEN) {
     logger.info('Configuring manual credentials for dynamo');
     config.credentials = {
         accessKeyId: AWS_ACCESS_KEY_ID,
-        secretAccessKey: AWS_SECRET_ACCESS_KEY
+        secretAccessKey: AWS_SECRET_ACCESS_KEY,
+        sessionToken: AWS_SESSION_TOKEN
     };
 }
 

--- a/src/Dynamo.js
+++ b/src/Dynamo.js
@@ -9,15 +9,20 @@ const logger = new Logger(__filename);
 
 const config = {
     region: AWS_DEFAULT_REGION,
+
 };
 
-if (AWS_ACCESS_KEY_ID && AWS_SECRET_ACCESS_KEY && AWS_SESSION_TOKEN) {
+if (AWS_ACCESS_KEY_ID && AWS_SECRET_ACCESS_KEY) {
     logger.info('Configuring manual credentials for dynamo');
     config.credentials = {
         accessKeyId: AWS_ACCESS_KEY_ID,
         secretAccessKey: AWS_SECRET_ACCESS_KEY,
-        sessionToken: AWS_SESSION_TOKEN
     };
+
+    if (AWS_SESSION_TOKEN) {
+        logger.info('Configuring manual session token for dynamo');
+        config.credentials.sessionToken = AWS_SESSION_TOKEN;
+    }
 }
 
 if (AWS_DYNAMO_ENDPOINT) {


### PR DESCRIPTION
### lambda default (no config)
```
config: {
accessKeyId: *******
secretAccessKey: ******
sessionToken: *****
}
```
✅ _has necessary access AND session token_

### without adding session key (current bug):
```
config: {
accessKeyId: *******
secretAccessKey: ******
}
```
❌ _this won't work because DynamoDB requires a session token, which is overwritten with only the access key and id_

### solution
```
config: {
accessKeyId: *******
secretAccessKey: ******
sessionToken: *****
}
```
✅ _also add the session token if it exists_
